### PR TITLE
Filter out videos in - (void)setupAlbums

### DIFF
--- a/BSImagePicker/Controller/BSImageSelectionController.m
+++ b/BSImagePicker/Controller/BSImageSelectionController.m
@@ -622,6 +622,8 @@ static NSString *kAlbumCellIdentifier = @"albumCellIdentifier";
     //Find all albums
     [[BSImageSelectionController defaultAssetsLibrary] enumerateGroupsWithTypes:ALAssetsGroupAll usingBlock:^(ALAssetsGroup *group, BOOL *stop) {
         if(group) {
+            ALAssetsFilter *onlyPhotosFilter = [ALAssetsFilter allPhotos];
+	    [group setAssetsFilter:onlyPhotosFilter];
             //Default to select saved photos album
             if([[group valueForProperty:ALAssetsGroupPropertyType] isEqual:[NSNumber numberWithInteger:ALAssetsGroupSavedPhotos]]) {
                 [self.photoAlbums insertObject:group atIndex:0];


### PR DESCRIPTION
In method "- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section" only ALAssetTypePhoto items are counted, e.g. if there are 276 items, 6 of which are videos, method will return 270.

Later, in "- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath", videos are not skipped, which means we will have always last 6 (== number of videos in album) photos missing.

Fix:
Add 
"ALAssetsFilter *onlyPhotosFilter = [ALAssetsFilter allPhotos];
            [group setAssetsFilter:onlyPhotosFilter];"
in "- (void)setupAlbums". After that, when enumerating assets in group, you will enumerate only photos, thus properly showing all of them.
