### PR TITLE
Add Carthage/Build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ DerivedData
 # `pod install` in .travis.yml
 #
 # Pods/
+
+# Carthage
+Carthage/Build


### PR DESCRIPTION
When using the option `--use-submodules` with Carthage, the `Carthage/Build` directory shows in the submodule after `carthage build` making the submodule dirty.