### PR TITLE
Added accessibility identifiers to cells for XCUITest compatibility

### DIFF
--- a/Pod/Classes/Model/CameraCollectionViewDataSource.swift
+++ b/Pod/Classes/Model/CameraCollectionViewDataSource.swift
@@ -47,6 +47,7 @@ final class CameraCollectionViewDataSource: NSObject, UICollectionViewDataSource
     
     func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
         let cameraCell = collectionView.dequeueReusableCellWithReuseIdentifier(cameraCellIdentifier, forIndexPath: indexPath) as! CameraCell
+        cameraCell.accessibilityIdentifier = "camera_cell_\(indexPath.item)"
         cameraCell.takePhotoIcon = settings.takePhotoIcon
         
         return cameraCell

--- a/Pod/Classes/Model/PhotoCollectionViewDataSource.swift
+++ b/Pod/Classes/Model/PhotoCollectionViewDataSource.swift
@@ -64,6 +64,7 @@ final class PhotoCollectionViewDataSource : NSObject, UICollectionViewDataSource
     func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
         UIView.setAnimationsEnabled(false)
         let cell = collectionView.dequeueReusableCellWithReuseIdentifier(photoCellIdentifier, forIndexPath: indexPath) as! PhotoCell
+        cell.accessibilityIdentifier = "photo_cell_\(indexPath.item)"
         if let settings = settings {
             cell.settings = settings
         }


### PR DESCRIPTION
In the tradition of offering a fix rather than only reporting an issue:

Currently, the BSImagePicker camera and photo cells don't have accessibility identifiers, which makes it problematic to build XCUITests that use them. This PR adds said accessIDs, so that one can call e.g. `app.cells["photo_cell_2"].tap()` in the XCUITest framework.