### PR TITLE
Fixed a problem with swift’s header generation

### DIFF
--- a/Pod/Classes/Controller/BSImagePickerViewController.swift
+++ b/Pod/Classes/Controller/BSImagePickerViewController.swift
@@ -46,12 +46,12 @@ open class BSImagePickerViewController : UINavigationController {
     /**
      Default selections
      */
-    open var defaultSelections: PHFetchResult<PHAsset>?
+    private var defaultSelections: PHFetchResult<PHAsset>?
     
     /**
      Fetch results.
      */
-    open lazy var fetchResults: [PHFetchResult] = { () -> [PHFetchResult<PHAssetCollection>] in 
+    private lazy var fetchResults: [PHFetchResult] = { () -> [PHFetchResult<PHAssetCollection>] in
         let fetchOptions = PHFetchOptions()
         
         // Camera roll fetch result


### PR DESCRIPTION
It seems that there is a bug with the swift compiler header generation. Changing the access control of these variables to private seems to fix the issue.
See: https://forums.developer.apple.com/thread/63156