### PR TITLE
Add `maximumSelectionReached` closure

### DIFF
--- a/Pod/Classes/Controller/BSImagePickerViewController.swift
+++ b/Pod/Classes/Controller/BSImagePickerViewController.swift
@@ -148,7 +148,19 @@ extension BSImagePickerViewController: BSImagePickerSettings {
             settings.maxNumberOfSelections = newValue
         }
     }
-    
+	
+	/**
+	See BSImagePicketSettings for documentation
+	*/
+	public var maximumSelectionReached: (() -> Void)? {
+		get {
+			return settings.maximumSelectionReached
+		}
+		set {
+			settings.maximumSelectionReached = newValue
+		}
+	}
+	
     /**
      See BSImagePicketSettings for documentation
      */

--- a/Pod/Classes/Controller/PhotosViewController.swift
+++ b/Pod/Classes/Controller/PhotosViewController.swift
@@ -298,7 +298,12 @@ extension PhotosViewController {
 
         // Make sure we have a data source and that we can make selections
         guard let photosDataSource = photosDataSource, collectionView.isUserInteractionEnabled else { return false }
-
+		
+		guard photosDataSource.selections.count < settings.maxNumberOfSelections else {
+			settings.maximumSelectionReached?()
+			return false
+		}
+		
         // We need a cell
         guard let cell = collectionView.cellForItem(at: indexPath) as? PhotoCell else { return false }
         let asset = photosDataSource.fetchResult.object(at: indexPath.row)

--- a/Pod/Classes/Model/Settings.swift
+++ b/Pod/Classes/Model/Settings.swift
@@ -27,6 +27,7 @@ The settings object that gets passed around between classes for keeping...settin
 */
 final class Settings : BSImagePickerSettings {
     var maxNumberOfSelections: Int = Int.max
+	var maximumSelectionReached: (() -> Void)?
     var selectionCharacter: Character? = nil
     var selectionFillColor: UIColor = UIView().tintColor
     var selectionStrokeColor: UIColor = UIColor.white

--- a/Pod/Classes/Protocol/BSImagePickerSettings.swift
+++ b/Pod/Classes/Protocol/BSImagePickerSettings.swift
@@ -30,7 +30,12 @@ public protocol BSImagePickerSettings {
     Max number of images user can select
     */
     var maxNumberOfSelections: Int { get set }
-    
+	
+	/**
+	Closure called when `maxNumberOfSelections` is reached
+	*/
+	var maximumSelectionReached: (() -> Void)? { get set }
+	
     /**
     Character to use for selection. If nil, selection number will be used
     */


### PR DESCRIPTION
Hey @mikaoj, thanks for this awesome library! :)

This PR is adding a `maximumSelectionReached` closure that is triggered when `maxNumberOfSelections` is reached. So you can show an alert or something if you want to ;)

Thanks for considering it!
