### PR TITLE
[iOS 10] Trigger Relayout of Navigation Bar When Changing Button

### DIFF
--- a/Pod/Classes/Controller/PhotosViewController.swift
+++ b/Pod/Classes/Controller/PhotosViewController.swift
@@ -259,6 +259,8 @@ final class PhotosViewController : UICollectionViewController {
                 }
             }
         }
+
+        self.navigationController?.navigationBar.setNeedsLayout()
     }
     
     // Check if a give UIButton is the right UIBarButtonItem in the navigation bar


### PR DESCRIPTION
On iOS 10, in our project, a layout update of the navigation bar is required for ensuring the selection/done button has the correct layout. Before adding the line we were seeing this glitch:

![img_0220](https://cloud.githubusercontent.com/assets/1423068/20362984/57401e46-abf2-11e6-89d6-581969ac87f9.png)
