### PR TITLE
Changed access modifier of fetchResults

### DIFF
--- a/Pod/Classes/Controller/BSImagePickerViewController.swift
+++ b/Pod/Classes/Controller/BSImagePickerViewController.swift
@@ -51,7 +51,7 @@ open class BSImagePickerViewController : UINavigationController {
     /**
      Fetch results.
      */
-    private lazy var fetchResults: [PHFetchResult] = { () -> [PHFetchResult<PHAssetCollection>] in
+    open lazy var fetchResults: [PHFetchResult] = { () -> [PHFetchResult<PHAssetCollection>] in
         let fetchOptions = PHFetchOptions()
         
         // Camera roll fetch result


### PR DESCRIPTION
I changed the access modifier of the fetchResults property from private to open. The documentation mentions using this property in the Custom Fetch Results section.