### PR TITLE
Added filtered results functionality to `PhotosViewController`

### DIFF
--- a/Pod/Classes/Controller/BSImagePickerViewController.swift
+++ b/Pod/Classes/Controller/BSImagePickerViewController.swift
@@ -49,6 +49,11 @@ open class BSImagePickerViewController : UINavigationController {
     open var defaultSelections: PHFetchResult<PHAsset>?
     
     /**
+     Filtered results
+     */
+    open var filteredResults: PHFetchResult<PHAsset>?
+    
+    /**
      Fetch results.
      */
     
@@ -69,13 +74,19 @@ open class BSImagePickerViewController : UINavigationController {
     static let bundle: Bundle = Bundle(path: Bundle(for: PhotosViewController.self).path(forResource: "BSImagePicker", ofType: "bundle")!)!
     
     lazy var photosViewController: PhotosViewController = {
-        let vc = PhotosViewController(fetchResults: self.fetchResults,
+        var vc: PhotosViewController
+        if let filteredResults = self.filteredResults {
+            vc = PhotosViewController(filteredResults: filteredResults,
                                       defaultSelections: self.defaultSelections,
                                       settings: self.settings)
-        
+        } else {
+            vc = PhotosViewController(fetchResults: self.fetchResults,
+                                      defaultSelections: self.defaultSelections,
+                                      settings: self.settings)
+            vc.albumTitleView = self.albumTitleView
+        }
         vc.doneBarButton = self.doneButton
         vc.cancelBarButton = self.cancelButton
-        vc.albumTitleView = self.albumTitleView
         
         return vc
     }()


### PR DESCRIPTION
Currently `PhotosViewController` is automatically created with `PHFetchResults<PHAssetCollection>` object (`fetchResults`). This PR adds ability to use new `filteredResults` property to use transient collections with manually added assets, like:

```swift
let assets = savedImagesData.flatMap { $0.asset }
let collection = PHAssetCollection.transientAssetCollection(with: assets, title: nil)
let fetchedAssets = PHAsset.fetchAssets(in: collection, options: nil)
imagePicker.filteredResults = fetchedAssets
```

`AlbumTitleView` is not used in this case, as we are not presenting any available album and we don't want the user to be able switch to different album. We want to show a specifically selected photo set not available in physically created album.

Also removed one duplicate `reloadData()` call ;)