### PR TITLE
Add selectLimitReachedClosure & minor UI test fix

### DIFF
--- a/Source/Controller/PhotosViewController.swift
+++ b/Source/Controller/PhotosViewController.swift
@@ -49,6 +49,7 @@ final class PhotosViewController : UICollectionViewController {
     @objc var deselectionClosure: ((_ asset: PHAsset) -> Void)?
     @objc var cancelClosure: ((_ assets: [PHAsset]) -> Void)?
     @objc var finishClosure: ((_ assets: [PHAsset]) -> Void)?
+    @objc var selectLimitReachedClosure: ((_ selectionLimit: Int) -> Void)?
     
     @objc var doneBarButton: UIBarButtonItem?
     @objc var cancelBarButton: UIBarButtonItem?
@@ -242,7 +243,7 @@ final class PhotosViewController : UICollectionViewController {
 
         navigationItem.rightBarButtonItem = doneBarButton
     }
-    
+
     @objc func updateAlbumTitle(_ album: PHAssetCollection) {
         guard let title = album.localizedTitle else { return }
         // Update album title
@@ -352,6 +353,11 @@ extension PhotosViewController {
                 DispatchQueue.global().async {
                     closure(asset)
                 }
+            }
+        } else if photosDataSource.selections.count >= settings.maxNumberOfSelections,
+            let closure = selectLimitReachedClosure {
+            DispatchQueue.global().async {
+                closure(self.settings.maxNumberOfSelections)
             }
         }
 

--- a/Source/Extension/UIViewController+BSImagePicker.swift
+++ b/Source/Extension/UIViewController+BSImagePicker.swift
@@ -37,8 +37,9 @@ public extension UIViewController {
         - parameter cancel: Closure to call when user cancels or nil
         - parameter finish: Closure to call when user finishes or nil
         - parameter completion: presentation completed closure or nil
+        - parameter selectLimitReachedClosure: Closure to call when user reaches selection limit or nil
     */
-    @objc func bs_presentImagePickerController(_ imagePicker: BSImagePickerViewController, animated: Bool, select: ((_ asset: PHAsset) -> Void)?, deselect: ((_ asset: PHAsset) -> Void)?, cancel: (([PHAsset]) -> Void)?, finish: (([PHAsset]) -> Void)?, completion: (() -> Void)?) {
+    @objc func bs_presentImagePickerController(_ imagePicker: BSImagePickerViewController, animated: Bool, select: ((_ asset: PHAsset) -> Void)?, deselect: ((_ asset: PHAsset) -> Void)?, cancel: (([PHAsset]) -> Void)?, finish: (([PHAsset]) -> Void)?, completion: (() -> Void)?, selectLimitReachedClosure: ((Int) -> Void)? = nil) {
         BSImagePickerViewController.authorize(fromViewController: self) { (authorized) -> Void in
             // Make sure we are authorized before proceding
             guard authorized == true else { return }
@@ -48,6 +49,7 @@ public extension UIViewController {
             imagePicker.photosViewController.deselectionClosure = deselect
             imagePicker.photosViewController.cancelClosure = cancel
             imagePicker.photosViewController.finishClosure = finish
+            imagePicker.photosViewController.selectLimitReachedClosure = selectLimitReachedClosure
             
             // Present
             self.present(imagePicker, animated: animated, completion: completion)

--- a/Source/Model/PhotoCollectionViewDataSource.swift
+++ b/Source/Model/PhotoCollectionViewDataSource.swift
@@ -64,6 +64,7 @@ final class PhotoCollectionViewDataSource : NSObject, UICollectionViewDataSource
         UIView.setAnimationsEnabled(false)
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: photoCellIdentifier, for: indexPath) as! PhotoCell
         cell.accessibilityIdentifier = "photo_cell_\(indexPath.item)"
+        cell.isAccessibilityElement = true
         if let settings = settings {
             cell.settings = settings
         }


### PR DESCRIPTION
We use this at PlanGrid, and we've been meaning to get back to using the original project (i.e. not our own fork) for some time. This contributes back the 2 pieces that we added, which led to us keeping the fork around:

- Adds the `selectLimitReachedClosure`, which is called
  when the user attempts select another cell, but the
  user has already reached the selection limit

- Marks the `UICollectionViewCell`s as
  `isAccessibilityElement = true`, which reduces UI
  test flakes/failures