### PR TITLE
Fix photo scale issue in photo and album views

### DIFF
--- a/Sources/Model/AlbumTableViewDataSource.swift
+++ b/Sources/Model/AlbumTableViewDataSource.swift
@@ -58,11 +58,12 @@ final class AlbumTableViewDataSource : NSObject, UITableViewDataSource {
             NSSortDescriptor(key: "creationDate", ascending: false)
         ]
         fetchOptions.predicate = NSPredicate(format: "mediaType = %d", PHAssetMediaType.image.rawValue)
-        
+
+        let scale = UIScreen.main.scale
+        let imageSize = CGSize(width: 79 * scale, height: 79 * scale)
+        let imageContentMode: PHImageContentMode = .aspectFill
         let result = PHAsset.fetchAssets(in: album, options: fetchOptions)
         result.enumerateObjects({ (asset, idx, stop) in
-            let imageSize = CGSize(width: 79, height: 79)
-            let imageContentMode: PHImageContentMode = .aspectFill
             switch idx {
             case 0:
                 PHCachingImageManager.default().requestImage(for: asset, targetSize: imageSize, contentMode: imageContentMode, options: nil) { (result, _) in

--- a/Sources/Model/PhotoCollectionViewDataSource.swift
+++ b/Sources/Model/PhotoCollectionViewDataSource.swift
@@ -34,7 +34,12 @@ final class PhotoCollectionViewDataSource : NSObject, UICollectionViewDataSource
     private let assetStore: AssetStore
     
     let settings: BSImagePickerSettings?
-    var imageSize: CGSize = CGSize.zero
+    var imageSize: CGSize = CGSize.zero {
+        didSet {
+            let scale = UIScreen.main.scale
+            imageSize = CGSize(width: imageSize.width * scale, height: imageSize.height * scale)
+        }
+    }
     
     init(fetchResult: PHFetchResult<PHAsset>, assetStore: AssetStore, settings: BSImagePickerSettings?) {
         self.fetchResult = fetchResult

--- a/Sources/View/AlbumCell.swift
+++ b/Sources/View/AlbumCell.swift
@@ -84,6 +84,7 @@ final class AlbumCell: UITableViewCell {
             $0.layer.shadowOffset = CGSize(width: 0.5, height: -0.5)
             $0.layer.shadowOpacity = 1.0
             $0.clipsToBounds = true
+            $0.contentMode = .scaleAspectFill
         }
 
         NSLayoutConstraint.activate([


### PR DESCRIPTION
Prior to this change the images extracted from PHImageManager didn't
accoutn for the device scale. This change ensures that the images are
extracted based on the user's device.

Reference:
https://stackoverflow.com/questions/31752527/does-phimagemanager-return-images-in-pixel-or-point-size-for-2x-and-3x-screens/36453340