### PR TITLE
Make `ImagePickerController` class open

### DIFF
--- a/Sources/Controller/ImagePickerController.swift
+++ b/Sources/Controller/ImagePickerController.swift
@@ -27,7 +27,7 @@ import Photos
 fileprivate let localizedDone = Bundle(identifier: "com.apple.UIKit")?.localizedString(forKey: "Done", value: "Done", table: "") ?? "Done"
 
 // MARK: ImagePickerController
-public class ImagePickerController: UINavigationController {
+open class ImagePickerController: UINavigationController {
     // MARK: Public properties
     public weak var imagePickerDelegate: ImagePickerControllerDelegate?
     public var settings: Settings = Settings()

--- a/Sources/Controller/ImagePickerController.swift
+++ b/Sources/Controller/ImagePickerController.swift
@@ -72,7 +72,7 @@ open class ImagePickerController: UINavigationController {
         super.init(nibName: nil, bundle: nil)
     }
 
-    required init?(coder aDecoder: NSCoder) {
+    public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 


### PR DESCRIPTION
Make `ImagePickerController` class open to enable sub-classing and further customizations, while `public` classes cannot be inherited in Swift.