### PR TITLE
enable preselected assets

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -98,9 +98,8 @@ class ViewController: UIViewController {
             }
         })
 
-        let imagePicker = ImagePickerController()
+        let imagePicker = ImagePickerController(selectedAssets: evenAssets)
         imagePicker.settings.fetch.assets.supportedMediaTypes = [.image]
-        imagePicker.assetStore = AssetStore(assets: evenAssets)
 
         self.presentImagePicker(imagePicker, select: { (asset) in
             print("Selected: \(asset)")

--- a/Sources/Controller/ImagePickerController.swift
+++ b/Sources/Controller/ImagePickerController.swift
@@ -34,9 +34,14 @@ open class ImagePickerController: UINavigationController {
     public var doneButton: UIBarButtonItem = UIBarButtonItem(title: localizedDone, style: .done, target: nil, action: nil)
     public var cancelButton: UIBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: nil, action: nil)
     public var albumButton: UIButton = UIButton(type: .custom)
-    public var assetStore: AssetStore = AssetStore(assets: [])
+    public var selectedAssets: [PHAsset] {
+        get {
+            return assetStore.assets
+        }
+    }
 
     // MARK: Internal properties
+    var assetStore: AssetStore
     var onSelection: ((_ asset: PHAsset) -> Void)?
     var onDeselection: ((_ asset: PHAsset) -> Void)?
     var onCancel: ((_ assets: [PHAsset]) -> Void)?
@@ -67,7 +72,8 @@ open class ImagePickerController: UINavigationController {
         }
     }()
 
-    public init() {
+    public init(selectedAssets: [PHAsset] = []) {
+        assetStore = AssetStore(assets: selectedAssets)
         assetsViewController = AssetsViewController(store: assetStore)
         super.init(nibName: nil, bundle: nil)
     }


### PR DESCRIPTION
- patch to enable preselected assets again
- don't require AssetStore being part of API, work with [PHAsset] only