### PR TITLE
Exposes Album member to Objective-C

### DIFF
--- a/BSImagePicker.podspec
+++ b/BSImagePicker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "BSImagePicker"
-  s.version          = "3.1.3"
+  s.version          = "3.1.4"
   s.summary          = "BSImagePicker is a multiple image picker for iOS. UIImagePickerController replacement"
   s.description      = <<-DESC
   A multiple image picker.

--- a/Sources/Model/Settings.swift
+++ b/Sources/Model/Settings.swift
@@ -101,7 +101,7 @@ import Photos
     }
 
     public class Fetch : NSObject {
-        public class Album {
+        public class Album : NSObject {
             /// Fetch options for albums/collections
             public lazy var options: PHFetchOptions = {
                 let fetchOptions = PHFetchOptions()


### PR DESCRIPTION
Hi, here I am again with a new class member that I need to access. It would be great if there was a magically way to expose them all — no, there isn't. Closer we have is the `@objcMembers` 😄

Thanks as always @mikaoj!