### PR TITLE
dark mode support

### DIFF
--- a/BSImagePicker.xcodeproj/project.pbxproj
+++ b/BSImagePicker.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		55CDB45F22347D640050D572 /* ZoomInteractionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CDB45E22347D640050D572 /* ZoomInteractionController.swift */; };
 		55F67B77222EEB2500805134 /* VideoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F67B76222EEB2500805134 /* VideoCollectionViewCell.swift */; };
 		55F67B7B222F088500805134 /* GradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F67B7A222F088500805134 /* GradientView.swift */; };
+		94DA6870247BDE5900CD5251 /* UIColor+BSImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94DA686F247BDE5900CD5251 /* UIColor+BSImagePicker.swift */; };
 		C2DC13CA23F75BDB0035FD13 /* NumberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2DC13C923F75BDA0035FD13 /* NumberView.swift */; };
 		C2DC13CC23F75BE40035FD13 /* SelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2DC13CB23F75BE40035FD13 /* SelectionView.swift */; };
 /* End PBXBuildFile section */
@@ -126,6 +127,7 @@
 		55DAB07F23145A8A00982A5B /* .travis.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .travis.yml; sourceTree = "<group>"; };
 		55F67B76222EEB2500805134 /* VideoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCollectionViewCell.swift; sourceTree = "<group>"; };
 		55F67B7A222F088500805134 /* GradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientView.swift; sourceTree = "<group>"; };
+		94DA686F247BDE5900CD5251 /* UIColor+BSImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+BSImagePicker.swift"; sourceTree = "<group>"; };
 		C2DC13C923F75BDA0035FD13 /* NumberView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberView.swift; sourceTree = "<group>"; };
 		C2DC13CB23F75BE40035FD13 /* SelectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -178,6 +180,7 @@
 				559DB81C21E78E4700CD58B4 /* Scene */,
 				550A315521D5298400AAF718 /* Info.plist */,
 				550A315421D5298400AAF718 /* BSImagePicker.h */,
+				94DA6871247BDE6400CD5251 /* Extension */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -327,6 +330,14 @@
 			path = Dropdown;
 			sourceTree = "<group>";
 		};
+		94DA6871247BDE6400CD5251 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				94DA686F247BDE5900CD5251 /* UIColor+BSImagePicker.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -454,6 +465,7 @@
 				5540480A232EB21D00BC846F /* CameraPreviewView.swift in Sources */,
 				5554729821E4E01700B90CA5 /* AssetStore.swift in Sources */,
 				559DB82121E7902400CD58B4 /* CameraViewController.swift in Sources */,
+				94DA6870247BDE5900CD5251 /* UIColor+BSImagePicker.swift in Sources */,
 				5554729D21E5248400B90CA5 /* ImagePickerController.swift in Sources */,
 				55C5B800222BD445003CF3F1 /* DropdownTransitionDelegate.swift in Sources */,
 				55BCF8D321D52C1000386752 /* AssetsCollectionViewDataSource.swift in Sources */,

--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -1,73 +1,72 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-<device id="retina4_7" orientation="portrait">
-<adaptation id="fullscreen"/>
-</device>
-<dependencies>
-<deployment identifier="iOS"/>
-<plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
-<capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
-</dependencies>
-<scenes>
-<!--View Controller-->
-<scene sceneID="tne-QT-ifu">
-<objects>
-<viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
-<layoutGuides>
-<viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
-<viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
-</layoutGuides>
-<view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-<rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-<autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-<subviews>
-<button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GFw-cP-rmQ">
-<rect key="frame" x="143.5" y="318.5" width="88" height="30"/>
-<state key="normal" title="Image picker">
-<color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-</state>
-<connections>
-<action selector="showImagePicker:" destination="BYZ-38-t0r" eventType="touchUpInside" id="LaC-Tl-d1J"/>
-</connections>
-</button>
-<button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DzO-ex-PdY">
-<rect key="frame" x="114.5" y="356.5" width="146" height="30"/>
-<constraints>
-<constraint firstAttribute="width" constant="146" id="Cd2-rJ-ekE"/>
-<constraint firstAttribute="height" constant="30" id="EKZ-hP-cGZ"/>
-</constraints>
-<state key="normal" title="Custom image picker">
-<color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-</state>
-<connections>
-<action selector="showCustomImagePicker:" destination="BYZ-38-t0r" eventType="touchUpInside" id="GKA-nS-l2H"/>
-</connections>
-</button>
-<button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zgs-tU-5p9">
-<rect key="frame" x="71.5" y="394.5" width="232" height="30"/>
-<constraints>
-<constraint firstAttribute="width" constant="232" id="IRj-9r-lbP"/>
-<constraint firstAttribute="height" constant="30" id="dDs-z0-Xqa"/>
-</constraints>
-<state key="normal" title="Image picker with selected assets"/>
-<connections>
-<action selector="showImagePickerWithSelectedAssets:" destination="BYZ-38-t0r" eventType="touchUpInside" id="m00-0a-bkf"/>
-</connections>
-</button>
-</subviews>
-<color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-<constraints>
-<constraint firstItem="zgs-tU-5p9" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="0A6-aX-1jb"/>
-<constraint firstAttribute="centerX" secondItem="DzO-ex-PdY" secondAttribute="centerX" id="EZn-Ed-pHh"/>
-<constraint firstItem="zgs-tU-5p9" firstAttribute="top" secondItem="DzO-ex-PdY" secondAttribute="bottom" constant="8" id="GUE-MX-lLP"/>
-<constraint firstAttribute="centerY" secondItem="GFw-cP-rmQ" secondAttribute="centerY" id="XmI-RH-XSN"/>
-<constraint firstItem="DzO-ex-PdY" firstAttribute="top" secondItem="GFw-cP-rmQ" secondAttribute="bottom" constant="8" id="j2M-qn-wIK"/>
-<constraint firstAttribute="centerX" secondItem="GFw-cP-rmQ" secondAttribute="centerX" id="vJT-bW-R2W"/>
-</constraints>
-</view>
-</viewController>
-<placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
-</objects>
-</scene>
-</scenes>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="ImagePicker" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GFw-cP-rmQ">
+                                <rect key="frame" x="143.5" y="318.5" width="88" height="30"/>
+                                <state key="normal" title="Image picker">
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="showImagePicker:" destination="BYZ-38-t0r" eventType="touchUpInside" id="LaC-Tl-d1J"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DzO-ex-PdY">
+                                <rect key="frame" x="114.5" y="356.5" width="146" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="146" id="Cd2-rJ-ekE"/>
+                                    <constraint firstAttribute="height" constant="30" id="EKZ-hP-cGZ"/>
+                                </constraints>
+                                <state key="normal" title="Custom image picker">
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="showCustomImagePicker:" destination="BYZ-38-t0r" eventType="touchUpInside" id="GKA-nS-l2H"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zgs-tU-5p9">
+                                <rect key="frame" x="71.5" y="394.5" width="232" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="232" id="IRj-9r-lbP"/>
+                                    <constraint firstAttribute="height" constant="30" id="dDs-z0-Xqa"/>
+                                </constraints>
+                                <state key="normal" title="Image picker with selected assets"/>
+                                <connections>
+                                    <action selector="showImagePickerWithSelectedAssets:" destination="BYZ-38-t0r" eventType="touchUpInside" id="m00-0a-bkf"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="zgs-tU-5p9" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="0A6-aX-1jb"/>
+                            <constraint firstAttribute="centerX" secondItem="DzO-ex-PdY" secondAttribute="centerX" id="EZn-Ed-pHh"/>
+                            <constraint firstItem="zgs-tU-5p9" firstAttribute="top" secondItem="DzO-ex-PdY" secondAttribute="bottom" constant="8" id="GUE-MX-lLP"/>
+                            <constraint firstAttribute="centerY" secondItem="GFw-cP-rmQ" secondAttribute="centerY" id="XmI-RH-XSN"/>
+                            <constraint firstItem="DzO-ex-PdY" firstAttribute="top" secondItem="GFw-cP-rmQ" secondAttribute="bottom" constant="8" id="j2M-qn-wIK"/>
+                            <constraint firstAttribute="centerX" secondItem="GFw-cP-rmQ" secondAttribute="centerX" id="vJT-bW-R2W"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="138" y="134"/>
+        </scene>
+    </scenes>
 </document>

--- a/Sources/Controller/ImagePickerController.swift
+++ b/Sources/Controller/ImagePickerController.swift
@@ -138,7 +138,7 @@ import Photos
 
         // We need to have some color to be able to match with the drop down
         if navigationBar.barTintColor == nil {
-            navigationBar.barTintColor = .white
+            navigationBar.barTintColor = .systemBackgroundColor
         }
 
         if let firstAlbum = albums.first {

--- a/Sources/Extension/UIColor+BSImagePicker.swift
+++ b/Sources/Extension/UIColor+BSImagePicker.swift
@@ -1,0 +1,86 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Shashank Mishra
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+extension UIColor {
+       
+    static var systemBackgroundColor: UIColor {
+        if #available(iOS 13.0, *) {
+            return systemBackground
+        } else {
+            // Same old color used for iOS 12 and earlier
+            return .white
+        }
+    }
+    
+    static var systemShadowColor: UIColor {
+       if #available(iOS 13.0, *) {
+            return tertiarySystemBackground
+        } else {
+            // Same old color used for iOS 12 and earlier
+            return .black
+        }
+    }
+    
+    static var systemPrimaryTextColor: UIColor {
+       if #available(iOS 13.0, *) {
+            return label
+        } else {
+            // Same old color used for iOS 12 and earlier
+            return .black
+        }
+    }
+    
+    static var systemSecondaryTextColor: UIColor {
+       if #available(iOS 13.0, *) {
+            return secondaryLabel
+        } else {
+            // Same old color used for iOS 12 and earlier
+            return .black
+        }
+    }
+    
+    static var systemStrokeColor: UIColor {
+        if #available(iOS 13.0, *) {
+            return UIColor { (traitCollection: UITraitCollection) -> UIColor in
+            if traitCollection.userInterfaceStyle == .dark {
+                return white
+            }
+            else {
+                return black
+            }}
+        } else {
+            // Same old color used for iOS 12 and earlier
+            return .black
+        }
+    }
+    
+    static var systemOverlayColor: UIColor {
+        if #available(iOS 13.0, *) {
+            return secondarySystemBackground
+        } else {
+            // Same old color used for iOS 12 and earlier
+            return .lightGray
+        }
+    }
+}

--- a/Sources/Model/Settings.swift
+++ b/Sources/Model/Settings.swift
@@ -30,16 +30,16 @@ import Photos
     // Move all theme related stuff to UIAppearance
     public class Theme : NSObject {
         /// Main background color
-        public lazy var backgroundColor: UIColor = .white
+        public lazy var backgroundColor: UIColor = .systemBackgroundColor
         
         /// What color to fill the circle with
         public lazy var selectionFillColor: UIColor = UIView().tintColor
         
-        /// Color for the actual selection icon
+        /// Color for the actual checkmark
         public lazy var selectionStrokeColor: UIColor = .white
         
         /// Shadow color for the circle
-        public lazy var selectionShadowColor: UIColor = .black
+        public lazy var selectionShadowColor: UIColor = .systemShadowColor
         
         public enum SelectionStyle {
             case checked
@@ -51,17 +51,17 @@ import Photos
         
         public lazy var previewTitleAttributes : [NSAttributedString.Key: Any] = [
             NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16),
-            NSAttributedString.Key.foregroundColor: UIColor.black
+            NSAttributedString.Key.foregroundColor: UIColor.systemPrimaryTextColor
         ]
         
         public lazy var previewSubtitleAttributes: [NSAttributedString.Key: Any] = [
             NSAttributedString.Key.font: UIFont.systemFont(ofSize: 12),
-            NSAttributedString.Key.foregroundColor: UIColor.black
+            NSAttributedString.Key.foregroundColor: UIColor.systemSecondaryTextColor
         ]
         
         public lazy var albumTitleAttributes: [NSAttributedString.Key: Any] = [
             NSAttributedString.Key.font: UIFont.systemFont(ofSize: 18),
-            NSAttributedString.Key.foregroundColor: UIColor.black
+            NSAttributedString.Key.foregroundColor: UIColor.systemPrimaryTextColor
         ]
     }
 

--- a/Sources/Scene/Assets/AssetCollectionViewCell.swift
+++ b/Sources/Scene/Assets/AssetCollectionViewCell.swift
@@ -69,7 +69,7 @@ class AssetCollectionViewCell: UICollectionViewCell {
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
-        selectionOverlayView.backgroundColor = UIColor.lightGray
+        selectionOverlayView.backgroundColor = UIColor.systemOverlayColor
         selectionOverlayView.translatesAutoresizingMaskIntoConstraints = false
         selectionView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(imageView)

--- a/Sources/Scene/Assets/VideoCollectionViewCell.swift
+++ b/Sources/Scene/Assets/VideoCollectionViewCell.swift
@@ -43,7 +43,7 @@ class VideoCollectionViewCell: AssetCollectionViewCell {
         
         durationLabel.textAlignment = .right
         durationLabel.text = "0:03"
-        durationLabel.textColor = .white
+        durationLabel.textColor = .systemPrimaryTextColor
         durationLabel.font = UIFont.boldSystemFont(ofSize: 12)
         durationLabel.translatesAutoresizingMaskIntoConstraints = false
         gradientView.addSubview(durationLabel)

--- a/Sources/Scene/Preview/PreviewViewController.swift
+++ b/Sources/Scene/Preview/PreviewViewController.swift
@@ -174,7 +174,7 @@ class PreviewViewController : UIViewController {
         if self.fullscreen && modalPresentationStyle == .fullScreen {
             aColor = UIColor.black
         } else {
-            aColor = UIColor.white
+            aColor = UIColor.systemBackgroundColor
         }
         
         view.backgroundColor = aColor

--- a/Sources/View/ArrowView.swift
+++ b/Sources/View/ArrowView.swift
@@ -62,7 +62,7 @@ class ArrowView: UIView {
     }
 
     var resizing: ResizingBehavior = .aspectFit
-    var strokeColor: UIColor = .black
+    var strokeColor: UIColor = .systemStrokeColor
 
     override var intrinsicContentSize: CGSize {
         return CGSize(width: 8, height: 8)


### PR DESCRIPTION
Hi Joakim,

I've added support for dark mode in the app(https://github.com/mikaoj/BSImagePicker/issues/264)

1. I ensured that devices working on iOS 13.0, will work as it is.
2. For iOS 13.0 and more, the basic color will change as per the color modes - dark and light
3. I've added the color extension which we can use it for setting any color in the app for any section. 


Please review and let me know if anything I can improve. 

Thanks
