### PR TITLE
Fixed layout issue with album dropdown on iPad

### DIFF
--- a/Sources/Presentation/Dropdown/DropdownPresentationController.swift
+++ b/Sources/Presentation/Dropdown/DropdownPresentationController.swift
@@ -55,23 +55,25 @@ class DropdownPresentationController: UIPresentationController {
     }
     
     override var frameOfPresentedViewInContainerView: CGRect {
-        guard let containerView = containerView else { return .zero }
-        
+        guard let containerView = containerView,
+            let presentingView = presentingViewController.view else { return .zero }
+
         let size = self.size(forChildContentContainer: presentedViewController,
-                          withParentContainerSize: containerView.bounds.size)
-        
+                          withParentContainerSize: presentingView.bounds.size)
+
         let position: CGPoint
         if let navigationBar = (presentingViewController as? UINavigationController)?.navigationBar {
             // We can't use the frame directly since iOS 13 new modal presentation style
             let navigationRect = navigationBar.convert(navigationBar.bounds, to: nil)
-            position = CGPoint(x: 0, y: navigationRect.height + navigationRect.origin.y)
+            let presentingRect = presentingView.convert(presentingView.frame, to: containerView)
+            position = CGPoint(x: presentingRect.origin.x, y: presentingRect.origin.y + navigationRect.height)
 
             // Match color with navigation bar
             presentedViewController.view.backgroundColor = navigationBar.barTintColor
         } else {
             position = .zero
         }
-        
+
         return CGRect(origin: position, size: size)
     }
 }


### PR DESCRIPTION
I've noticed that the album dropdown exceeds the bounds of the presenting sheet on iPad:

![bsimagepicker-ipad-dropdown](https://user-images.githubusercontent.com/5102728/83536311-564b3900-a4f3-11ea-8c6b-08e7a3de447e.png)

I've created a small PR to fix this issue.

![bsimagepicker-ipad-dropdown-fixed](https://user-images.githubusercontent.com/5102728/83536723-e4272400-a4f3-11ea-9ed2-adc823080c32.png)
