### PR TITLE
Allow swipe to dismiss the image picker

### DIFF
--- a/BSImagePicker.xcodeproj/project.pbxproj
+++ b/BSImagePicker.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		94DA6870247BDE5900CD5251 /* UIColor+BSImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94DA686F247BDE5900CD5251 /* UIColor+BSImagePicker.swift */; };
 		C2DC13CA23F75BDB0035FD13 /* NumberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2DC13C923F75BDA0035FD13 /* NumberView.swift */; };
 		C2DC13CC23F75BE40035FD13 /* SelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2DC13CB23F75BE40035FD13 /* SelectionView.swift */; };
+		DCB6D3A42486A68D0057A2D4 /* ImagePickerController+PresentationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB6D3A32486A68D0057A2D4 /* ImagePickerController+PresentationDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -130,6 +131,7 @@
 		94DA686F247BDE5900CD5251 /* UIColor+BSImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+BSImagePicker.swift"; sourceTree = "<group>"; };
 		C2DC13C923F75BDA0035FD13 /* NumberView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberView.swift; sourceTree = "<group>"; };
 		C2DC13CB23F75BE40035FD13 /* SelectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectionView.swift; sourceTree = "<group>"; };
+		DCB6D3A32486A68D0057A2D4 /* ImagePickerController+PresentationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImagePickerController+PresentationDelegate.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -264,6 +266,7 @@
 				559DB81621E6AFD800CD58B4 /* ImagePickerController+Assets.swift */,
 				559DB81821E6AFF300CD58B4 /* ImagePickerController+Albums.swift */,
 				559DB81A21E6B43400CD58B4 /* ImagePickerController+ButtonActions.swift */,
+				DCB6D3A32486A68D0057A2D4 /* ImagePickerController+PresentationDelegate.swift */,
 				559DB80E21E655D000CD58B4 /* ImagePickerControllerDelegate.swift */,
 			);
 			path = Controller;
@@ -476,6 +479,7 @@
 				559DB80F21E655D000CD58B4 /* ImagePickerControllerDelegate.swift in Sources */,
 				559DB81721E6AFD800CD58B4 /* ImagePickerController+Assets.swift in Sources */,
 				55CDB45B223435420050D572 /* PlayerView.swift in Sources */,
+				DCB6D3A42486A68D0057A2D4 /* ImagePickerController+PresentationDelegate.swift in Sources */,
 				C2DC13CC23F75BE40035FD13 /* SelectionView.swift in Sources */,
 				559DB81921E6AFF300CD58B4 /* ImagePickerController+Albums.swift in Sources */,
 				55BCF8D721D52C1000386752 /* CheckmarkView.swift in Sources */,

--- a/Sources/Controller/ImagePickerController+PresentationDelegate.swift
+++ b/Sources/Controller/ImagePickerController+PresentationDelegate.swift
@@ -1,0 +1,39 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Felix Lisczyk
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+extension ImagePickerController: UIAdaptivePresentationControllerDelegate {
+
+    @available(iOS 13, *)
+    public func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
+        return settings.dismiss.enabled && settings.dismiss.allowSwipe
+    }
+
+    // This method is only called if
+    // - the presented view controller is not dismissed programmatically and
+    // - its `isModalInPresentation` property is set to false.
+    @available(iOS 13, *)
+    public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        imagePickerDelegate?.imagePicker(self, didCancelWithAssets: assetStore.assets)
+    }
+}

--- a/Sources/Controller/ImagePickerController+PresentationDelegate.swift
+++ b/Sources/Controller/ImagePickerController+PresentationDelegate.swift
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import Foundation
+import UIKit
 
 extension ImagePickerController: UIAdaptivePresentationControllerDelegate {
 

--- a/Sources/Controller/ImagePickerController.swift
+++ b/Sources/Controller/ImagePickerController.swift
@@ -87,11 +87,6 @@ import Photos
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-
-        if #available(iOS 13.0, *) {
-            // Disables iOS 13 swipe to dismiss - to force user to press cancel or done.
-            isModalInPresentation = true
-        }
         
         // Sync settings
         albumsViewController.settings = settings
@@ -103,7 +98,10 @@ import Photos
         
         viewControllers = [assetsViewController]
         view.backgroundColor = settings.theme.backgroundColor
+
+        // Setup delegates
         delegate = zoomTransitionDelegate
+        presentationController?.delegate = self
 
         // Turn off translucency so drop down can match its color
         navigationBar.isTranslucent = false

--- a/Sources/Model/Settings.swift
+++ b/Sources/Model/Settings.swift
@@ -187,6 +187,9 @@ import Photos
     public class Dismiss : NSObject {
         /// Should the image picker dismiss when done/cancelled
         public lazy var enabled = true
+
+        /// Allow the user to dismiss the image picker by swiping down
+        public lazy var allowSwipe = false
     }
 
     /// Theme settings


### PR DESCRIPTION
This PR adds a new option `Settings.Dismiss.allowSwipe`, which allows the user to close the image picker by swiping down on the screen. I believe this feature is expected by many users in a modern iOS 13 app. I've set the default value of this option to `false` to ensure backwards compatibility.

Thank you for considering my changes! Please feel free to make any edits.
