### PR TITLE
Save-restore last used album

### DIFF
--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -52,14 +52,28 @@
                                     <action selector="showImagePickerWithSelectedAssets:" destination="BYZ-38-t0r" eventType="touchUpInside" id="m00-0a-bkf"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pyy-Wk-n2s">
+                                <rect key="frame" x="90" y="432.5" width="195" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="e8n-Nr-IrY"/>
+                                </constraints>
+                                <state key="normal" title="Image picker with last album">
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="showImagePickerWithAlbums:" destination="BYZ-38-t0r" eventType="touchUpInside" id="R9s-Hs-nqn"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="zgs-tU-5p9" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="0A6-aX-1jb"/>
                             <constraint firstAttribute="centerX" secondItem="DzO-ex-PdY" secondAttribute="centerX" id="EZn-Ed-pHh"/>
                             <constraint firstItem="zgs-tU-5p9" firstAttribute="top" secondItem="DzO-ex-PdY" secondAttribute="bottom" constant="8" id="GUE-MX-lLP"/>
+                            <constraint firstItem="Pyy-Wk-n2s" firstAttribute="top" secondItem="zgs-tU-5p9" secondAttribute="bottom" constant="8" id="IKo-Ze-hE5"/>
                             <constraint firstAttribute="centerY" secondItem="GFw-cP-rmQ" secondAttribute="centerY" id="XmI-RH-XSN"/>
                             <constraint firstItem="DzO-ex-PdY" firstAttribute="top" secondItem="GFw-cP-rmQ" secondAttribute="bottom" constant="8" id="j2M-qn-wIK"/>
+                            <constraint firstItem="Pyy-Wk-n2s" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="spv-Vo-MiH"/>
                             <constraint firstAttribute="centerX" secondItem="GFw-cP-rmQ" secondAttribute="centerX" id="vJT-bW-R2W"/>
                         </constraints>
                     </view>

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -47,6 +47,39 @@ class ViewController: UIViewController {
             print(finish.timeIntervalSince(start))
         })
     }
+
+    private var lastSelectedAlbum: String?
+    @IBAction func showImagePickerWithAlbums(_ sender: UIButton) {
+        let imagePicker = ImagePickerController()
+        imagePicker.settings.selection.max = 3
+        imagePicker.settings.theme.selectionStyle = .checked
+        imagePicker.settings.fetch.assets.supportedMediaTypes = [.image, .video]
+        imagePicker.settings.selection.unselectOnReachingMax = false
+
+        imagePicker.selectedAlbumIdentifier = lastSelectedAlbum
+        //Show the "Recent" album and all other ones available
+        let options = imagePicker.settings.fetch.album.options
+        imagePicker.settings.fetch.album.fetchResults = [
+            PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .smartAlbumUserLibrary, options: options),
+            PHAssetCollection.fetchAssetCollections(with: .album, subtype: .albumRegular, options: options),
+        ]
+
+        let start = Date()
+        self.presentImagePicker(imagePicker, select: { (asset) in
+            print("Selected: \(asset)")
+        }, deselect: { (asset) in
+            print("Deselected: \(asset)")
+        }, cancel: { [weak self] (assets) in
+            self?.lastSelectedAlbum = imagePicker.selectedAlbumIdentifier
+            print("Canceled with selections: \(assets)")
+        }, finish: { [weak self] (assets) in
+            self?.lastSelectedAlbum = imagePicker.selectedAlbumIdentifier
+            print("Finished with selections: \(assets)")
+        }, completion: {
+            let finish = Date()
+            print(finish.timeIntervalSince(start))
+        })
+    }
     
     @IBAction func showCustomImagePicker(_ sender: UIButton) {
         let imagePicker = ImagePickerController()

--- a/Sources/Controller/ImagePickerController.swift
+++ b/Sources/Controller/ImagePickerController.swift
@@ -49,6 +49,7 @@ import Photos
     var onDeselection: ((_ asset: PHAsset) -> Void)?
     var onCancel: ((_ assets: [PHAsset]) -> Void)?
     var onFinish: ((_ assets: [PHAsset]) -> Void)?
+    public var selectedAlbumIdentifier: String?
     
     let assetsViewController: AssetsViewController
     let albumsViewController = AlbumsViewController()
@@ -139,7 +140,10 @@ import Photos
             navigationBar.barTintColor = .systemBackgroundColor
         }
 
-        if let firstAlbum = albums.first {
+        if let selectedAlbumIdentifier = selectedAlbumIdentifier, let selectedAlbum = albums.first(where: { $0.localIdentifier == selectedAlbumIdentifier }) {
+            select(album: selectedAlbum)
+        } else if let firstAlbum = albums.first {
+            selectedAlbumIdentifier = firstAlbum.localIdentifier    //so the check mark appears in the albums list
             select(album: firstAlbum)
         }
     }


### PR DESCRIPTION
Allow to retrieve and restore the last used album in the picker. Make the album selection indicator more stable (e.x. current album does not have check mark until the cell reload (scroll the cell out of the visible area, scroll to))