### PR TITLE
Currently BSImagePicker has issues on Xcode 12.

### DIFF
--- a/Sources/Model/Settings.swift
+++ b/Sources/Model/Settings.swift
@@ -23,7 +23,7 @@
 import UIKit
 import Photos
 
-/// Settings for BSImagePicker
+@objc(BSSettings) // Fix for ObjC header name conflicting.
 @objcMembers public class Settings : NSObject {
     public static let shared = Settings()
 


### PR DESCRIPTION
Xcode show build error when user has 'Settings.swift' same name class.
It is Objc header conflict issue.
also I got error too because my project has 'Settings' Coredata model class.