### PR TITLE
Fix dropdown position

### DIFF
--- a/Sources/Presentation/Dropdown/DropdownPresentationController.swift
+++ b/Sources/Presentation/Dropdown/DropdownPresentationController.swift
@@ -66,7 +66,7 @@ class DropdownPresentationController: UIPresentationController {
             // We can't use the frame directly since iOS 13 new modal presentation style
             let navigationRect = navigationBar.convert(navigationBar.bounds, to: nil)
             let presentingRect = presentingView.convert(presentingView.frame, to: containerView)
-            position = CGPoint(x: presentingRect.origin.x, y: presentingRect.origin.y + navigationRect.height)
+            position = CGPoint(x: presentingRect.origin.x, y: navigationRect.maxY)
 
             // Match color with navigation bar
             presentedViewController.view.backgroundColor = navigationBar.barTintColor


### PR DESCRIPTION
If I set `imagePicker.modalPresentationStyle = .fullScreen`, the position of dropdown `AlbumsViewController` will be wrong.