### PR TITLE
Fix selected assets are not removed after the corresponding photo is deleted

### DIFF
--- a/Sources/Scene/Assets/AssetsViewController.swift
+++ b/Sources/Scene/Assets/AssetsViewController.swift
@@ -217,7 +217,9 @@ extension AssetsViewController: PHPhotoLibraryChangeObserver {
                         let removedItems = removed.map { IndexPath(item: $0, section:0) }
                         let removedSelections = self.collectionView.indexPathsForSelectedItems?.filter { return removedItems.contains($0) }
                         removedSelections?.forEach {
-                            self.delegate?.assetsViewController(self, didDeselectAsset: changes.fetchResultBeforeChanges.object(at: $0.row))
+                            let removedAsset = changes.fetchResultBeforeChanges.object(at: $0.row)
+                            self.store.remove(removedAsset)
+                            self.delegate?.assetsViewController(self, didDeselectAsset: removedAsset)
                         }
                         self.collectionView.deleteItems(at: removedItems)
                     }


### PR DESCRIPTION
Steps to reproduce:

1. Select some photos
2. Go to Photos app to delete photos just selected
3. Back to example app

You will find that the selected photos are gone, but the number displayed on the `doneButton` has not changed. The reason is that the selected assets are not removed from the `store`.