### PR TITLE
 Improve Objc access in controller, settings, and gradient view

### DIFF
--- a/Sources/Controller/ImagePickerController.swift
+++ b/Sources/Controller/ImagePickerController.swift
@@ -24,6 +24,7 @@ import UIKit
 import Photos
 
 // MARK: ImagePickerController
+@objc(BSImagePickerController)
 @objcMembers open class ImagePickerController: UINavigationController {
     // MARK: Public properties
     public weak var imagePickerDelegate: ImagePickerControllerDelegate?

--- a/Sources/Model/Settings.swift
+++ b/Sources/Model/Settings.swift
@@ -64,8 +64,9 @@ import Photos
             NSAttributedString.Key.foregroundColor: UIColor.systemPrimaryTextColor
         ]
     }
-
-    public class Selection : NSObject {
+    
+    @objc(BSImagePickerSelection)
+    @objcMembers public class Selection : NSObject {
         /// Max number of selections allowed
         public lazy var max: Int = Int.max
         
@@ -76,7 +77,8 @@ import Photos
         @objc public lazy var unselectOnReachingMax : Bool = false
     }
 
-    public class List : NSObject {
+    @objc(BSImagePickerList)
+    @objcMembers public class List : NSObject {
         /// How much spacing between cells
         public lazy var spacing: CGFloat = 2
         
@@ -100,8 +102,10 @@ import Photos
         public lazy var enabled: Bool = true
     }
 
-    public class Fetch : NSObject {
-        public class Album : NSObject {
+    @objc(BSImagePickerFetch)
+    @objcMembers public class Fetch : NSObject {
+        @objc(BSImagePickerAlbum)
+        @objcMembers public class Album : NSObject {
             /// Fetch options for albums/collections
             public lazy var options: PHFetchOptions = {
                 let fetchOptions = PHFetchOptions()
@@ -120,7 +124,8 @@ import Photos
             ]
         }
 
-        public class Assets : NSObject {
+        @objc(BSImagePickerAssets)
+        @objcMembers public class Assets : NSObject {
             /// Fetch options for assets
 
             /// Simple wrapper around PHAssetMediaType to ensure we only expose the supported types.

--- a/Sources/Scene/Assets/GradientView.swift
+++ b/Sources/Scene/Assets/GradientView.swift
@@ -23,6 +23,7 @@
 import Foundation
 import UIKit
 
+@objc(BSImagePickerGradientView)
 class GradientView: UIView {
     override class var layerClass: AnyClass {
         return CAGradientLayer.self


### PR DESCRIPTION
Allows ObjC code to access additional configuration classes and their variables (Selection, List, Fetch, Album, Assets) and improves a few class naming issues when used in ObjC projects (ImagePickerController, GradientView).
Should have zero effect on Swift users.

===================
Tip for ObjC users: ObjC code is unable to access the MediaTypes enum-struct to set supportedMediaTypes. To 
 change the default of "images only", you can manually override the fetch predicate like so:
```
BSImagePickerController *bsImagePicker = [[BSImagePickerController alloc] initWithSelectedAssets:@[]];
PHFetchOptions *fetchOptions = bsImagePicker.settings.fetch.assets.options;
// Include both images and video
fetchOptions.predicate = [NSPredicate predicateWithFormat:@"mediaType = %d OR mediaType = %d", PHAssetMediaTypeImage, PHAssetMediaTypeVideo];
```