### PR TITLE
Configurable album overlay background and default starting point for album overlay proposal

### DIFF
--- a/Sources/Model/Settings.swift
+++ b/Sources/Model/Settings.swift
@@ -32,6 +32,9 @@ import Photos
         /// Main background color
         public lazy var backgroundColor: UIColor = .systemBackgroundColor
         
+        /// Color for backgroun of drop downs
+        public lazy var dropDownBackgroundColor: UIColor = .clear
+        
         /// What color to fill the circle with
         public lazy var selectionFillColor: UIColor = UIView().tintColor
         

--- a/Sources/Presentation/Dropdown/DropdownPresentationController.swift
+++ b/Sources/Presentation/Dropdown/DropdownPresentationController.swift
@@ -71,7 +71,11 @@ class DropdownPresentationController: UIPresentationController {
             // Match color with navigation bar
             presentedViewController.view.backgroundColor = navigationBar.barTintColor
         } else {
-            position = .zero
+            if #available(iOS 11.0, *) {
+                position = CGPoint(x: containerView.safeAreaInsets.left, y: containerView.safeAreaInsets.top)
+            } else {
+                position = .zero
+            }
         }
 
         return CGRect(origin: position, size: size)

--- a/Sources/Scene/Albums/AlbumsViewController.swift
+++ b/Sources/Scene/Albums/AlbumsViewController.swift
@@ -57,7 +57,7 @@ class AlbumsViewController: UIViewController {
         tableView.register(AlbumCell.self, forCellReuseIdentifier: AlbumCell.identifier)
         tableView.dataSource = dataSource
         tableView.delegate = self
-        tableView.backgroundColor = .clear
+        tableView.backgroundColor = settings.theme.backgroundColor
         view.addSubview(tableView)
 
         let lineHeight: CGFloat = 0.5

--- a/Sources/Scene/Albums/AlbumsViewController.swift
+++ b/Sources/Scene/Albums/AlbumsViewController.swift
@@ -57,7 +57,7 @@ class AlbumsViewController: UIViewController {
         tableView.register(AlbumCell.self, forCellReuseIdentifier: AlbumCell.identifier)
         tableView.dataSource = dataSource
         tableView.delegate = self
-        tableView.backgroundColor = settings.theme.backgroundColor
+        tableView.backgroundColor = settings.theme.dropDownBackgroundColor
         view.addSubview(tableView)
 
         let lineHeight: CGFloat = 0.5


### PR DESCRIPTION
I was using this picker on a swiftui project and was asked to add albums to the picker I noticed issue #268

This PR adds: 
- configurable background color to albumviewcontroller based on the theme  
- checks for safe area insets if there is no navigation controller 

In the DropdownPresentationController in swiftUI you can get:
```
type(of: presentingViewController)
> SwiftUI.SheetHostingController
```
And I'm not sure if we can get the underlying navigation bar height. 
However, instead of defaulting to `.zero` respecting safe area insets might be a nicer solution.
