### PR TITLE
Defer accessing fetchResults settings

### DIFF
--- a/Sources/Controller/ImagePickerController.swift
+++ b/Sources/Controller/ImagePickerController.swift
@@ -64,7 +64,7 @@ import Photos
         let fetchOptions = settings.fetch.assets.options.copy() as! PHFetchOptions
         fetchOptions.fetchLimit = 1
 
-        return settings.fetch.album.fetchResults.filter {
+        return settings.fetch.album.fetchResults().filter {
             $0.count > 0
         }.flatMap {
             $0.objects(at: IndexSet(integersIn: 0..<$0.count))

--- a/Sources/Model/Settings.swift
+++ b/Sources/Model/Settings.swift
@@ -119,9 +119,11 @@ import Photos
             ///                PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .smartAlbumSelfPortraits, options: options),
             ///                PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .smartAlbumPanoramas, options: options),
             ///                PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .smartAlbumVideos, options: options),
-            public lazy var fetchResults: [PHFetchResult<PHAssetCollection>] = [
-                PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .smartAlbumUserLibrary, options: options),
-            ]
+            public lazy var fetchResults: () -> [PHFetchResult<PHAssetCollection>] = { [options] in
+                return [
+                    PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .smartAlbumUserLibrary, options: options),
+                ]
+            }
         }
 
         @objc(BSImagePickerAssets)


### PR DESCRIPTION
**Issue**

Setting custom fetchResults prior to obtaining Photos permission from the user results in null AssetCollections, and thus will present an empty ImagePickerController the first time it is presented.

For instance

```
let imagePickerVC = ImagePickerController()
imagePickerVC.settings.fetch.album.fetchResults = [PHAssetCollection.fetchAssetCollection(with: .album, subtype: .albumRegular, options: PHFetchOptions())]
imagePickerVC.presentImagePicker(...
```
will have the effect of presenting an empty picker the first time after permissions are first granted.

**Proposed solution**
Defer the access of the fetchResults settings by using a function rather than a var.

**Note**
There are other ways of solving this, such as adding an `onAuthorization` closure to the `presentImagePicker` call and allowing settings to be passed in there.