### PR TITLE
Reset with first album when there're no album after user granted some of photos

### DIFF
--- a/Sources/Controller/ImagePickerController+Albums.swift
+++ b/Sources/Controller/ImagePickerController+Albums.swift
@@ -34,6 +34,7 @@ extension ImagePickerController: AlbumsViewControllerDelegate {
     }
 
     func select(album: PHAssetCollection) {
+        self.currentAlbum = album
         assetsViewController.showAssets(in: album)
         albumButton.setTitle((album.localizedTitle ?? "") + " ", for: .normal)
         albumButton.sizeToFit()

--- a/Sources/Controller/ImagePickerController.swift
+++ b/Sources/Controller/ImagePickerController.swift
@@ -56,7 +56,7 @@ import Photos
     let dropdownTransitionDelegate = DropdownTransitionDelegate()
     let zoomTransitionDelegate = ZoomTransitionDelegate()
 
-    lazy var albums: [PHAssetCollection] = {
+    private func loadAlbums() -> [PHAssetCollection] {
         // We don't want collections without assets.
         // I would like to do that with PHFetchOptions: fetchOptions.predicate = NSPredicate(format: "estimatedAssetCount > 0")
         // But that doesn't work...
@@ -74,6 +74,11 @@ import Photos
             let assetsFetchResult = PHAsset.fetchAssets(in: $0, options: fetchOptions)
             return assetsFetchResult.count > 0
         }
+    }
+    var currentAlbum: PHAssetCollection?
+
+    lazy var albums: [PHAssetCollection] = {
+        self.loadAlbums()
     }()
 
     public init(selectedAssets: [PHAsset] = []) {
@@ -84,6 +89,16 @@ import Photos
 
     public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    open override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        PHPhotoLibrary.shared().register(self)
+    }
+
+    open override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        PHPhotoLibrary.shared().unregisterChangeObserver(self)
     }
 
     public override func viewDidLoad() {
@@ -159,5 +174,21 @@ import Photos
 
     func updateAlbumButton() {
         albumButton.isHidden = albums.count < 2
+    }
+}
+
+extension ImagePickerController: PHPhotoLibraryChangeObserver {
+    public func photoLibraryDidChange(_ changeInstance: PHChange) {
+        if let currentAlbum = currentAlbum,
+           changeInstance.changeDetails(for: currentAlbum) != nil {
+            return
+        }
+        DispatchQueue.main.async {
+            self.albums = self.loadAlbums()
+            self.updateAlbumButton()
+            if let firstAlbum = self.albums.first {
+                self.select(album: firstAlbum)
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolved #328

The issue raised when the ImagePickerController appears before launch `tLimitedLibraryPicker` and after granted some of photos the ImagePickerController cannot detect any changes from PhotoLibrary since there're no active album. So in this case, we need reload albums and redo setup things.