### PR TITLE
Provide default implementations of ImagePickerControllerDelegate protocol

### DIFF
--- a/Sources/Controller/ImagePickerControllerDelegate.swift
+++ b/Sources/Controller/ImagePickerControllerDelegate.swift
@@ -50,3 +50,16 @@ public protocol ImagePickerControllerDelegate: class {
     /// - Parameter count: Number of selected assets.
     func imagePicker(_ imagePicker: ImagePickerController, didReachSelectionLimit count: Int)
 }
+
+public extension ImagePickerControllerDelegate {
+
+    func imagePicker(_ imagePicker: ImagePickerController, didSelectAsset asset: PHAsset) {}
+
+    func imagePicker(_ imagePicker: ImagePickerController, didDeselectAsset asset: PHAsset) {}
+
+    func imagePicker(_ imagePicker: ImagePickerController, didFinishWithAssets assets: [PHAsset]) {}
+
+    func imagePicker(_ imagePicker: ImagePickerController, didCancelWithAssets assets: [PHAsset]) {}
+
+    func imagePicker(_ imagePicker: ImagePickerController, didReachSelectionLimit count: Int) {}
+}


### PR DESCRIPTION
When I use `BSImagePicker` library and implement `ImagePickerControllerDelegate` protocol, I just needed `imagePicker(_:didFinishWithAssets:)` function.

So, I suggest providing default implementations of the protocol.

After that, you can implement functions which you want, not all.

Thank you!