### PR TITLE
Bump MacOS target version to 11.0 in order to support building for Catalyst

### DIFF
--- a/BSImagePicker.xcodeproj/project.pbxproj
+++ b/BSImagePicker.xcodeproj/project.pbxproj
@@ -655,6 +655,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -686,6 +687,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
Project fails to compile on Mac Catalyst because of various errors:
`'AVCaptureVideoPreviewLayer' is only available in Mac Catalyst 14.0 or newer`

Bumping the MacOS target version to 11.0 fixes the issue, without any effect on backwards compatibility for iOS targets.