### PR TITLE
Fix a collectionView.selectItem crash issue

### DIFF
--- a/Sources/Scene/Assets/AssetsViewController.swift
+++ b/Sources/Scene/Assets/AssetsViewController.swift
@@ -112,6 +112,10 @@ class AssetsViewController: UIViewController {
             let index = fetchResult.index(of: asset)
             guard index != NSNotFound else { continue }
             let indexPath = IndexPath(item: index, section: 0)
+
+            let numberOfItems = collectionView.numberOfItems(inSection: 0)
+            guard index + 1 <= numberOfItems else { continue }
+
             collectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
             updateSelectionIndexForCell(at: indexPath)
         }


### PR DESCRIPTION
@mikaoj

I faced a crash at follows.
```
collectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
```
https://github.com/mikaoj/BSImagePicker/blob/master/Sources/Scene/Assets/AssetsViewController.swift#L115C13-L115C90

The error I faced is as follows.
```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Attempted to modify the selection of an out-of-bounds item (2) when there are only 0 items in section 0. Collection view:
```

I fixed this issue by adding `guard`.

Thank you for maintaining the very useful package!
