### PR TITLE
feat: add .xcprivacy file for privacy api's

### DIFF
--- a/BSImagePicker.podspec
+++ b/BSImagePicker.podspec
@@ -13,9 +13,9 @@ Pod::Spec.new do |s|
 
   s.platform     = :ios, '10.0'
   s.requires_arc = true
-  s.swift_version = '5.1'
+  s.swift_version = '5.7'
 
   s.source_files = 'Sources/**/*.swift'
-
+  s.resource_bundle = { 'BSImagePicker' => ['Sources/Resources/PrivacyInfo.xcprivacy']}
   s.frameworks = 'UIKit', 'Photos'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "BSImagePicker",
-    platforms: [.iOS(.v10)],
+    platforms: [.iOS(.v12)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
@@ -22,7 +22,11 @@ let package = Package(
         .target(
             name: "BSImagePicker",
             dependencies: [],
-            path: "Sources"),
+            path: "Sources",
+            resources: [
+                .copy("Resources/PrivacyInfo.xcprivacy")
+            ]
+        ),
         .testTarget(
             name: "Tests",
             dependencies: ["BSImagePicker"],

--- a/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
#359 

The PR has the following updates: 
* Adding the .xcprivacy file which lists reason for usage of the required reason API's. 
* Updating the swift tool version to 5.7 which gives the ability for SPM to add resource folders
* Updated package.swift file to add privacy file
* Updated podspec to add information about the privacy file. 

Testing: 

Generated a privacy report, Archive the app which consumes the library using SPM, and then in Xcode -> Window -> Organizer -> Under Archives, right click on the archive -> Generate Privacy Report.