### PR TITLE
fix NSInternalInconsistencyException crash

### DIFF
--- a/Sources/Scene/Assets/AssetsViewController.swift
+++ b/Sources/Scene/Assets/AssetsViewController.swift
@@ -208,9 +208,9 @@ extension AssetsViewController: UICollectionViewDelegate {
 
 extension AssetsViewController: PHPhotoLibraryChangeObserver {
     func photoLibraryDidChange(_ changeInstance: PHChange) {
-        guard let changes = changeInstance.changeDetails(for: fetchResult) else { return }
         // Since we are gonna update UI, make sure we are on main
         DispatchQueue.main.async {
+            guard let changes = changeInstance.changeDetails(for: self.fetchResult) else { return }
             if changes.hasIncrementalChanges {
                 self.collectionView.performBatchUpdates({
                     self.fetchResult = changes.fetchResultAfterChanges


### PR DESCRIPTION
I experienced an issue "Invalid batch updates detected", when the main thread was busy working. 

The `photoLibraryDidChange` function would be called multiple times on background thread and `changes` fetched by old `fetchResult` caused NSInternalInconsistencyException crash in async main dispatch block.

This change eliminates the possibility that fetched changes will be stale. 😀