### PR TITLE
Fix albums view in SwiftUI issue #366

### DIFF
--- a/Sources/Presentation/Dropdown/DropdownPresentationController.swift
+++ b/Sources/Presentation/Dropdown/DropdownPresentationController.swift
@@ -32,14 +32,16 @@ class DropdownPresentationController: UIPresentationController {
         super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
         
         self.source = source
-        backgroundView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        backgroundView.backgroundColor = .clear
-        backgroundView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(backgroundTapped(_:))))
+        setupBackgroundView()
     }
     
     override init(presentedViewController: UIViewController, presenting presentingViewController: UIViewController?) {
         super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
         
+        self.setupBackgroundView()
+    }
+    
+    private func setupBackgroundView() {
         backgroundView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         backgroundView.backgroundColor = .clear
         backgroundView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(backgroundTapped(_:))))

--- a/Sources/Presentation/Dropdown/DropdownPresentationController.swift
+++ b/Sources/Presentation/Dropdown/DropdownPresentationController.swift
@@ -26,6 +26,16 @@ import UIKit
 class DropdownPresentationController: UIPresentationController {
     private let dropDownHeight: CGFloat = 200
     private let backgroundView = UIView()
+    private weak var source: UIViewController?
+    
+    init(presentedViewController: UIViewController, presenting presentingViewController: UIViewController?, source: UIViewController) {
+        super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
+        
+        self.source = source
+        backgroundView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        backgroundView.backgroundColor = .clear
+        backgroundView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(backgroundTapped(_:))))
+    }
     
     override init(presentedViewController: UIViewController, presenting presentingViewController: UIViewController?) {
         super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
@@ -62,7 +72,7 @@ class DropdownPresentationController: UIPresentationController {
                           withParentContainerSize: presentingView.bounds.size)
 
         let position: CGPoint
-        if let navigationBar = (presentingViewController as? UINavigationController)?.navigationBar {
+        if let navigationBar = (source as? UINavigationController)?.navigationBar {
             // We can't use the frame directly since iOS 13 new modal presentation style
             let navigationRect = navigationBar.convert(navigationBar.bounds, to: nil)
             let presentingRect = presentingView.convert(presentingView.frame, to: containerView)

--- a/Sources/Presentation/Dropdown/DropdownTransitionDelegate.swift
+++ b/Sources/Presentation/Dropdown/DropdownTransitionDelegate.swift
@@ -25,7 +25,7 @@ import UIKit
 
 class DropdownTransitionDelegate: NSObject, UIViewControllerTransitioningDelegate {
     func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
-        return DropdownPresentationController(presentedViewController: presented, presenting: presenting)
+        return DropdownPresentationController(presentedViewController: presented, presenting: presenting, source: source)
     }
     
     func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {


### PR DESCRIPTION
After use SwiftUI wrapper `ImagePickerController`, the presentingViewController is not a UINavigationController in `frameOfPresentedViewInContainerView` of `DropdownPresentationController`, so setting of the position and background color of `AlbumsViewController` is incorrect.
Pass source to DropdownPresentationController to fix.